### PR TITLE
set DEFAULT_AUTO_FIELD to AutoField

### DIFF
--- a/django_celery_monitor/apps.py
+++ b/django_celery_monitor/apps.py
@@ -9,7 +9,7 @@ __all__ = ['CeleryMonitorConfig']
 
 class CeleryMonitorConfig(AppConfig):
     """Default configuration for the django_celery_monitor app."""
-
+    default_auto_field = 'django.db.models.AutoField'
     name = 'django_celery_monitor'
     label = 'celery_monitor'
     verbose_name = _('Celery Monitor')


### PR DESCRIPTION
we do this change in order to avoid `(models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.` when using Django 3.2

